### PR TITLE
Fix connection abort if serverPing/serverPong is enabled

### DIFF
--- a/modules_meshcore/routeplus.js
+++ b/modules_meshcore/routeplus.js
@@ -187,7 +187,7 @@ function RoutePlusRoute() {
             c.on('end', function () { disconnectTunnel(this, this.websocket, "Client closed"); });
             c.pause();
             try {
-                var options = http.parseUri(rObj.settings.serverurl + '?auth=' + latestAuthCookie + '&nodeid=' + rObj.settings.remotenodeid + '&tcpport=' + rObj.settings.remoteport + (rObj.settings.remotetarget == null ? '' : '&tcpaddr=' + rObj.settings.remotetarget));
+                var options = http.parseUri(rObj.settings.serverurl + '?noping=1&auth=' + latestAuthCookie + '&nodeid=' + rObj.settings.remotenodeid + '&tcpport=' + rObj.settings.remoteport + (rObj.settings.remotetarget == null ? '' : '&tcpaddr=' + rObj.settings.remotetarget));
             } catch (e) { dbg("Unable to parse \"serverUrl\"." + e); return; }
             options.checkServerIdentity = this.onVerifyServer;
             options.rejectUnauthorized = false;


### PR DESCRIPTION
Hi @ryanblenis,

thanks for your work on the MeshCentral plugings.

I got into trouble with forwarded tcp ports if serverPing or serverPong is enabled on the server. The reason are the ping-pong messages in the control channel.

The quick fix as requested to pull is to send `noping=1` as query parameter to the server. Another solution might be to handle those messages or to make it selectable in UI. Maybe one day ... :-)

agentPing is set to 10

**Without the fix:**
```
$ ssh johndoe@localhost -p 33655 "while sleep 1; do printf '\\r%4d ' \${SECONDS}; done"
   9 Bad packet length 4059767367.
ssh_dispatch_run_fatal: Connection to 127.0.0.1 port 33655: Connection corrupted
```
**With the fix:**
```
$ ssh johndoe@localhost -p 33655 "while sleep 1; do printf '\\r%4d ' \${SECONDS}; done"
1898 ^C
```
**Refereces:**

[`meshrelay.js#L347`](https://github.com/Ylianst/MeshCentral/blob/9398afd07e371ce035c7a68cc55642f4f95db21e/meshrelay.js#L347)
```
// Setup the agent PING/PONG timers unless requested not to
if ((obj.req.query.noping != 1) && (obj.peer.req != null) && (obj.peer.req.query != null) && (obj.peer.req.query.noping != 1))

```
[`meshrelay.js#L1262`](https://github.com/Ylianst/MeshCentral/blob/9398afd07e371ce035c7a68cc55642f4f95db21e/meshrelay.js#L1262)
```
// Send a PING/PONG message
function sendPing() { try { obj.ws.send('{"ctrlChannel":"102938","type":"ping"}'); } catch (ex) { } }
function sendPong() { try { obj.ws.send('{"ctrlChannel":"102938","type":"pong"}'); } catch (ex) { } }
```
